### PR TITLE
Use password in ConnectionPool when opening connections

### DIFF
--- a/asonic/client.py
+++ b/asonic/client.py
@@ -13,7 +13,7 @@ def escape(t):
 
 
 class Client:
-    def __init__(self, host: str = 'localhost', port: int = 1491, password: str = 'SecretPassword',
+    def __init__(self, host: str = 'localhost', port: int = 1491, password: str = '',
                  max_connections: int = 100):
         self.host = host
         self.port = port
@@ -36,7 +36,8 @@ class Client:
                 setattr(self, command.lower(), mock)
         self._channel = channel
         self.pool = ConnectionPool(host=self.host, port=self.port, channel=channel,
-                                   max_connections=self.max_connections)
+                                   max_connections=self.max_connections,
+                                   password=self.password)
 
     async def query(self,
                     collection: str,

--- a/asonic/client.py
+++ b/asonic/client.py
@@ -13,7 +13,7 @@ def escape(t):
 
 
 class Client:
-    def __init__(self, host: str = 'localhost', port: int = 1491, password: str = '',
+    def __init__(self, host: str = 'localhost', port: int = 1491, password: str = 'SecretPassword',
                  max_connections: int = 100):
         self.host = host
         self.port = port

--- a/asonic/connection.py
+++ b/asonic/connection.py
@@ -5,7 +5,7 @@ from asonic.exceptions import ServerError, ConnectionClosed
 
 
 class Connection:
-    def __init__(self, host, port, channel, password='SecretPassword'):
+    def __init__(self, host, port, channel, password):
         self.host = host
         self.port = port
         self.channel = channel
@@ -37,7 +37,7 @@ class Connection:
 
 
 class ConnectionPool:
-    def __init__(self, host: str, port: int, channel: str, max_connections: int = 100):
+    def __init__(self, host: str, port: int, channel: str, password: str, max_connections: int = 100):
         self.closed = False
         self._created_connections = 0
         self._available_connections = asyncio.Queue()
@@ -45,6 +45,7 @@ class ConnectionPool:
         self.max_connections = max_connections
         self.host = host
         self.port = port
+        self.password = password
         self.channel = channel
 
     async def get_connection(self) -> Connection:
@@ -61,7 +62,7 @@ class ConnectionPool:
         if self._created_connections >= self.max_connections:
             return await self._available_connections.get()
         self._created_connections += 1
-        c = Connection(self.host, self.port, self.channel)
+        c = Connection(self.host, self.port, self.channel, self.password)
         await c.connect()
         return c
 


### PR DESCRIPTION
I noticed that because a default value was used for the password it wasn't possible to connect with any other password. The `Connection` object was using the default password, but the `ConnectionPool` didn't get the value passed in from the `Client`.