### PR TITLE
Improved client creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ from asonic.enums import Channel
 
 
 async def main():
-  c = Client(host='127.0.0.1', port=1491, password='SecretPassword', max_connections=100)
-  await c.channel(Channel.SEARCH)
+  c = await Client.create(
+    host="127.0.0.1",
+    port=1491,
+    password="SecretPassword",
+    channel=Channel.SEARCH,
+    max_connections=100
+  )
   assert (await c.query('collection', 'bucket', 'quick')) == [b'user_id']
   assert (await c.suggest('collection', 'bucket', 'br', 1)) == [b'brown']
 
@@ -38,8 +43,13 @@ from asonic.enums import Channel
 
 
 async def main():
-  c = Client(host='127.0.0.1', port=1491)
-  await c.channel(Channel.INGEST)
+  c = await Client.create(
+    host="127.0.0.1",
+    port=1491,
+    password="SecretPassword",
+    channel=Channel.INGEST,
+    max_connections=100
+  )
   await c.push('collection', 'bucket', 'user_id', 'The quick brown fox jumps over the lazy dog')
   # Return b'OK'
   await c.pop('collection', 'bucket', 'user_id', 'The')
@@ -61,8 +71,12 @@ from asonic.enums import Channel, Action
 
 
 async def main():
-  c = Client(host='127.0.0.1', port=1491)
-  await c.channel(Channel.CONTROL)
+  c = await Client.create(
+    host="127.0.0.1",
+    port=1491,
+    password="SecretPassword",
+    channel=Channel.CONTROL,
+  )
   await c.trigger(Action.CONSOLIDATE)
   # Return b'OK'
 

--- a/asonic/client.py
+++ b/asonic/client.py
@@ -13,7 +13,11 @@ def escape(t):
 
 class Client:
     def __init__(
-        self, host: str = 'localhost', port: int = 1491, password: str = 'SecretPassword', max_connections: int = 100
+        self,
+        host: str = 'localhost',
+        port: int = 1491,
+        password: str = 'SecretPassword',
+        max_connections: int = 100
     ):
         self.host = host
         self.port = port
@@ -22,6 +26,24 @@ class Client:
 
         self._channel = Channel.UNINITIALIZED
         self.pool = None  # type: Optional[ConnectionPool]
+
+    @classmethod
+    async def create(
+        self,
+        host: str = 'localhost',
+        port: int = 1491,
+        password: str = 'SecretPassword',
+        channel: Channel = Channel.SEARCH,
+        max_connections: int = 100
+    ):
+        client: Client = Client(
+            host=host,
+            port=port,
+            password=password,
+            max_connections=max_connections
+        )
+        _ = await client.channel(channel=channel)
+        return client
 
     async def channel(self, channel: Channel) -> None:
         if self._channel != Channel.UNINITIALIZED:
@@ -41,6 +63,8 @@ class Client:
             max_connections=self.max_connections,
             password=self.password,
         )
+        # force check if connection can be made
+        _ = await self.ping()
 
     async def query(
         self, collection: str, bucket: str, terms: str, limit: int = None, offset: int = None, locale: str = None

--- a/asonic/connection.py
+++ b/asonic/connection.py
@@ -23,7 +23,13 @@ class Connection:
         assert result.startswith(b'CONNECTED')
 
         await self.write(f'START {self.channel.value} {self.password}')
-        await self.read()
+        result = await self.read()
+        if result.startswith(b'STARTED'):
+            pass
+        elif result.startswith(b'ENDED'):
+            raise ConnectionClosed(f"Error {result}")
+        else:
+            raise ServerError(f"Unknown error {result}")
 
     async def write(self, msg: str) -> None:
         assert self.writer is not None, 'connect'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       sonic:
         condition: service_healthy
   sonic:
-    image: valeriansaliou/sonic:v1.2.0
+    image: valeriansaliou/sonic:v1.4.9
     volumes:
       - ./tests/config.cfg:/etc/sonic.cfg
     healthcheck:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-import pytest
+import pytest_asyncio
 
 from asonic import Client
 from asonic.enums import Channel
@@ -8,28 +8,28 @@ from asonic.enums import Channel
 collection = 'collection'
 
 
-@pytest.fixture(autouse=True)
+@pytest_asyncio.fixture
 async def clean():
     c = Client(host=getenv('SONIC_HOST', 'localhost'), port=1491)
     await c.channel(Channel.INGEST)
     await c.flushc(collection)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def search() -> Client:
     c = Client(host=getenv('SONIC_HOST', 'localhost'), port=1491)
     await c.channel(Channel.SEARCH)
     return c
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def ingest():
     c = Client(host=getenv('SONIC_HOST', 'localhost'), port=1491)
     await c.channel(Channel.INGEST)
     return c
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def control():
     c = Client(host=getenv('SONIC_HOST', 'localhost'), port=1491)
     await c.channel(Channel.CONTROL)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext as does_not_raise
 import pytest
 from uuid import uuid4
 
@@ -8,6 +9,12 @@ from asonic.exceptions import ClientError, ConnectionClosed
 collection = 'collection'
 
 pytestmark = pytest.mark.asyncio
+
+async def test_client_init():
+    with does_not_raise():
+        _client = await Client.create(host="localhost", port=1491, password="SecretPassword")
+    with pytest.raises(ConnectionClosed):
+        _client = await Client.create(host="localhost", port=1491, password="invalid")
 
 async def test_ping(search, ingest):
     assert await search.ping() == b'PONG'

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,5 @@
 import pytest
+from uuid import uuid4
 
 from asonic import Client
 from asonic.enums import Action, Channel
@@ -8,14 +9,13 @@ collection = 'collection'
 
 pytestmark = pytest.mark.asyncio
 
-
 async def test_ping(search, ingest):
     assert await search.ping() == b'PONG'
     assert await ingest.ping() == b'PONG'
 
 
 async def test_help(search):
-    assert await search.help('commands') == b'RESULT commands(QUERY, SUGGEST, PING, HELP, QUIT)'
+    assert await search.help('commands') == b'RESULT commands(QUERY, SUGGEST, LIST, PING, HELP, QUIT)'
 
 
 async def test_empty(search):
@@ -24,13 +24,13 @@ async def test_empty(search):
 
 
 async def test_suggest(search, ingest, control):
-    bucket = 'bucket:1'
-    uid = 'uid'
-    assert (await ingest.push(collection, bucket, uid, 'RESULT commands(QUERY, SUGGEST, PING, HELP, QUIT)')) == b'OK'
+    bucket = str(uuid4())
+    uid = str(uuid4())
+    assert (await ingest.push(collection, bucket, uid, 'RESULT commands(QUERY, SUGGEST, LIST, PING, HELP, QUIT)')) == b'OK'
     assert (await control.trigger(Action.CONSOLIDATE)) == b'OK'
     assert (await search.suggest(collection, bucket, 'comm')) == [b'commands']
     assert (await search.suggest(collection, bucket, 'Q')) == [b'query', b'quit']
-    assert (await ingest.count(collection, bucket, uid)) == 5
+    assert (await ingest.count(collection, bucket, uid)) == 8
 
 
 async def test_info(control):
@@ -39,15 +39,15 @@ async def test_info(control):
 
 
 async def test_query(search, ingest):
-    bucket = 'bucket:1'
-    uid = 'uid'
+    bucket = str(uuid4())
+    uid = str(uuid4())
     assert (await ingest.push(collection, bucket, uid, 'The quick brown fox jumps over the lazy dog')) == b'OK'
     assert (await search.query(collection, bucket, 'quick', 1, 0)) == [uid.encode()]
 
 
 async def test_flushb(search, ingest):
-    bucket = 'bucket:1'
-    uid = 'uid'
+    bucket = str(uuid4())
+    uid = str(uuid4())
     assert (await ingest.push(collection, bucket, uid, 'The quick brown fox jumps over the lazy dog')) == b'OK'
     assert (await search.query(collection, bucket, 'quick')) == [uid.encode()]
     assert (await ingest.flushb(collection, bucket)) == 1
@@ -55,8 +55,8 @@ async def test_flushb(search, ingest):
 
 
 async def test_flushc(search, ingest):
-    bucket = 'bucket:1'
-    uid = 'uid'
+    bucket = str(uuid4())
+    uid = str(uuid4())
     assert (await ingest.push(collection, bucket, uid, 'The quick brown fox jumps over the lazy dog')) == b'OK'
     assert (await search.query(collection, bucket, 'quick')) == [uid.encode()]
     assert (await ingest.flushc(collection)) == 1
@@ -64,8 +64,8 @@ async def test_flushc(search, ingest):
 
 
 async def test_flusho(search, ingest):
-    bucket = 'bucket:1'
-    uid = 'uid'
+    bucket = str(uuid4())
+    uid = str(uuid4())
     assert (await ingest.push(collection, bucket, uid, 'The quick brown fox jumps over the lazy dog')) == b'OK'
     assert (await search.query(collection, bucket, 'quick')) == [uid.encode()]
     assert (await ingest.flusho(collection, bucket, uid)) == 6
@@ -83,8 +83,8 @@ async def test_quit(search):
 
 
 async def test_pop(search, ingest):
-    bucket = 'bucket:1'
-    uid = 'uid'
+    bucket = str(uuid4())
+    uid = str(uuid4())
     assert (await ingest.push(collection, bucket, uid, 'The quick brown fox jumps over the lazy dog')) == b'OK'
     assert (await ingest.pop(collection, bucket, uid, 'quick')) == 1
     assert (await ingest.count(collection, bucket, uid)) == 5
@@ -92,9 +92,9 @@ async def test_pop(search, ingest):
 
 
 async def test_limit_offset(search, ingest):
-    bucket = 'bucket:1'
-    uid = 'uid'
-    uid2 = 'uid2'
+    bucket = str(uuid4())
+    uid = str(uuid4())
+    uid2 = str(uuid4())
     assert (await ingest.push(collection, bucket, uid, 'The quick brown fox jumps over the lazy dog')) == b'OK'
     assert (await ingest.push(collection, bucket, uid2,
                               'The quick brown fox jumps over the lazy dog complete')) == b'OK'


### PR DESCRIPTION
There is a bug where initializing a client with an incorrect password does not immediately raise an exception. Instead all subsequent commands fail without a descriptive error.

```
>>> c = Client(host='127.0.0.1', port=1491, password="bad")
>>> await c.channel(Channel.INGEST)
>>> await c.push('collection', 'bucket', 'user_id', 'The quick brown fox jumps over the lazy dog')
Traceback (most recent call last):
  File "/home/piotr/Documents/Github/asonic/asonic/connection.py", line 60, in get_connection
    connection = self._available_connections.get_nowait()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/queues.py", line 181, in get_nowait
    raise QueueEmpty
asyncio.queues.QueueEmpty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "<console>", line 1, in <module>
  File "/home/piotr/Documents/Github/asonic/asonic/client.py", line 124, in push
    return await self._command(Command.PUSH, collection, bucket, obj, escape(text), locale=locale)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piotr/Documents/Github/asonic/asonic/client.py", line 206, in _command
    c = await self.pool.get_connection()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piotr/Documents/Github/asonic/asonic/connection.py", line 62, in get_connection
    connection = await self.make_connection()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piotr/Documents/Github/asonic/asonic/connection.py", line 71, in make_connection
    await c.connect()
  File "/home/piotr/Documents/Github/asonic/asonic/connection.py", line 27, in connect
    assert result.startswith(b'STARTED')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

This PR fixes this.

Moreover, since client can only have one channel (and it cannot be changed after setting it first time), I added an additional method for initializing it it one step. Current way of initializing clients with 2 calls still works the same.

Additional changes are updating tests for latest sonic/pytest versions.