### PR TITLE
Fix bug in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import sys
 
 from setuptools import setup
 
-if sys.version < '3.4':
-    raise RuntimeError('python 3.4 required')
+if sys.version_info < (3, 4):
+    raise RuntimeError('Python version must be at least 3.4')
 
 try:
     import pypandoc


### PR DESCRIPTION
If using python 3.10, 3.11, 3.12, 3.13 and so on, then checking `< "3.4"` gives the wrong result. I decided to also change the message because I found the message confusing when I got it (it made me think that the version had to be *exactly* version 3.4).